### PR TITLE
Add filename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,6 @@ Set `DEBUG` Config var to `breezy-pdf-lite:*` to get debugged output.
 
 ### Run Tests
 
+`$ /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --interpreter none --headless   --disable-gpu   --disable-translate   --disable-extensions   --disable-background-networking   --safebrowsing-disable-auto-update   --disable-sync   --metrics-recording-only   --disable-default-apps   --no-first-run   --mute-audio   --hide-scrollbars   --remote-debugging-port=9222`
+
 `$ npm test`

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,6 @@
 const htmlPdf           = require('html-pdf-chrome')
 const debug             = require('debug')
+const uuid              = require('uuid')
 const meta              = require('./meta')
 const PrintOptions      = require('./pdf/print-options')
 const CompletionTrigger = require('./pdf/completion-trigger')
@@ -31,6 +32,10 @@ module.exports = class Render {
     }
 
     return this.metadata
+  }
+
+  filename() {
+    return `${this.meta().filename || uuid()}.pdf`
   }
 
   printOptions() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,9 @@ module.exports = class Server {
       const renderer = new Render(req.body)
       try {
         pdf = await renderer.toPdf()
-        res.status(201).send(pdf.toBuffer())
+        res.status(201)
+          .set('Content-Disposition', `attachment; filename="${renderer.filename()}"`)
+          .send(pdf.toBuffer())
       } catch (error) {
         this.log(error)
         res.status(500).send('Encountered an error while generating PDF. Check the server logs for more details')

--- a/test/lib/integration/web-test.js
+++ b/test/lib/integration/web-test.js
@@ -7,6 +7,7 @@ const port  = server.port,
 const htmlString = `
   <html>
     <head>
+      <meta name='breezy-pdf-filename' content='fancyfilename'/>
       <meta name='breezy-pdf-width' content='10'/>
     </head>
     <body>
@@ -50,6 +51,10 @@ module.exports = {
 
           assert(Buffer, buffer.constructor)
           done()
+        },
+
+        contentDisposition() {
+          assert.equal(this.response.headers.get('content-disposition'), 'attachment; filename="fancyfilename.pdf"')
         }
       },
 

--- a/test/lib/render-test.js
+++ b/test/lib/render-test.js
@@ -4,6 +4,7 @@ let Render
 const htmlString = `
   <html>
     <head>
+      <meta name='breezy-pdf-filename' content='fancyfilename'/>
       <meta name='breezy-pdf-width' content='10'/>
     </head>
     <body>
@@ -38,5 +39,15 @@ module.exports = {
   toPdf() {
     td.when(this.htmlPdf.create(htmlString, td.matchers.isA(Object))).thenReturn(true)
      assert.equal(true, new Render(htmlString).toPdf())
+  },
+
+  filename: {
+    specified() {
+      assert.equal('fancyfilename.pdf', new Render(htmlString).filename())
+    },
+
+    notSpecified() {
+      assert(new Render('').filename().match(/\.pdf$/))
+    }
   }
 }


### PR DESCRIPTION
Specify the filename and disposition of the PDF using the Content-Disposition header. If no filename is specified via metadata, generate a UUID.