### PR TITLE
Add support for specifying the starting URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ const webServer = new Server({
 console.log('Starting Google Chrome')
 
 ChromeLauncher.launch({
-  chromeFlags: ['--headless', '--disable-gpu', '--disable-dev-shm-usage', '--no-sandbox', '--hide-scrollbars'],
-  port: 9222
+  chromeFlags: ['--disable-gpu', '--disable-dev-shm-usage', '--no-sandbox', '--hide-scrollbars'],
+  port: 9222,
+  startingUrl: (process.env.STARTING_URL || 'about:blank')
 }).then((chrome) => {
   console.log(`Chrome debugging port running on ${chrome.port}`)
 


### PR DESCRIPTION
Some JS API's check the http referer when used (Google Maps JS API, for example). Specify the `STARTING_URL` as an env variable to set ensure these requests function as expected.