### PR TITLE
Replace meta passed filename extension

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -35,7 +35,7 @@ module.exports = class Render {
   }
 
   filename() {
-    return `${this.meta().filename || uuid()}.pdf`
+    return `${(this.meta().filename || uuid()).split('.')[0]}.pdf`
   }
 
   printOptions() {

--- a/test/lib/render-test.js
+++ b/test/lib/render-test.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 let Render
 
-const htmlString = `
+let htmlString = `
   <html>
     <head>
       <meta name='breezy-pdf-filename' content='fancyfilename'/>
@@ -48,6 +48,20 @@ module.exports = {
 
     notSpecified() {
       assert(new Render('').filename().match(/\.pdf$/))
+    },
+
+    alreadyHasExtension() {
+      htmlString = `
+        <html>
+          <head>
+            <meta name='breezy-pdf-filename' content='fancyfilename.pdf'/>
+          </head>
+          <body>
+          </body>
+        </html>
+      `.trim()
+
+      assert.equal('fancyfilename.pdf', new Render(htmlString).filename())
     }
   }
 }


### PR DESCRIPTION
Force the filename to end in `.pdf`. Removes passed file extension, if any, and replaces with `.pdf`.

Fixes #93