### PR TITLE
Add HTTP compression for responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
 const ChromeLauncher = require('chrome-launcher')
 const Server         = require('./lib/server')
 
+const compressionOptions = {
+  level:     process.env.COMPRESSION_LEVEL || -1,
+  chunkSize: process.env.COMPRESSION_CHUNK_SIZE || 16384,
+  memLevel:  process.env.COMPRESSION_MEM_LEVEL || 8
+}
+
 const webServer = new Server({
-  port:  process.env.PORT || 5001,
-  privateToken: process.env.PRIVATE_TOKEN
+  port:         process.env.PORT || 5001,
+  privateToken: process.env.PRIVATE_TOKEN,
+  compression:  compressionOptions
 })
 
 console.log('Starting Google Chrome')

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,5 @@
 const express       = require('express')
+const compression   = require('compression')
 const bodyParser    = require('body-parser')
 const debug         = require('debug')
 const Authorization = require('./authorization')
@@ -7,11 +8,13 @@ const Render        = require('./render')
 module.exports = class Server {
   constructor(options) {
     this.options = options || {
-      port:         5001,
-      privateToken: process.env.PRIVATE_TOKEN
+      port:               5001,
+      privateToken:       process.env.PRIVATE_TOKEN,
+      compressionOptions: {}
     }
 
     this.app = express()
+    this.app.use(compression(this.options.compressionOptions))
     this.log = debug(this.options.log || 'breezy-pdf-lite:server')
   }
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "chrome-launcher": "^0.13.3",
+    "compression": "^1.7.4",
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "html-pdf-chrome": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,7 +219,7 @@ abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-accepts@~1.3.7:
+accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   dependencies:
@@ -466,6 +466,11 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -621,6 +626,26 @@ commander@~2.20.3:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+compressible@~2.0.16:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
+
+compression@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1920,6 +1945,11 @@ mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
 
+"mime-db@>= 1.43.0 < 2":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
+  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
+
 mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
@@ -2103,6 +2133,11 @@ on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@1.x, once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Add http response compression middleware via [compression](https://github.com/expressjs/compression).

Support for configuring with the following ENV variables:

```javascript
compressionOptions = {
  level:     process.env.COMPRESSION_LEVEL || -1,
  chunkSize: process.env.COMPRESSION_CHUNK_SIZE || 16384,
  memLevel:  process.env.COMPRESSION_MEM_LEVEL || 8
}
```